### PR TITLE
Updated to remove map sync issue

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 
 	// Packages
-	types "github.com/mutablelogic/go-pg/pkg/types"
 	pgx "github.com/jackc/pgx/v5"
+	types "github.com/mutablelogic/go-pg/pkg/types"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -56,8 +56,14 @@ func (bind *Bind) Copy(pairs ...any) *Bind {
 		return nil
 	}
 
-	varsCopy := make(pgx.NamedArgs, len(bind.vars)+len(pairs)>>1)
-	maps.Copy(varsCopy, bind.vars)
+	// Lock before copying
+	varsCopy := func() pgx.NamedArgs {
+		bind.RLock()
+		defer bind.RUnlock()
+		c := make(pgx.NamedArgs, len(bind.vars)+len(pairs)>>1)
+		maps.Copy(c, bind.vars)
+		return c
+	}()
 
 	for i := 0; i < len(pairs); i += 2 {
 		if key, ok := pairs[i].(string); !ok || key == "" {


### PR DESCRIPTION
This PR addresses a concurrency issue in the Copy method of the Bind struct by adding proper synchronization when copying the internal vars map. The import statements are also reordered alphabetically.
