### PR TITLE
Added version command and fixed http flag

### DIFF
--- a/cmd/pgmanager/main.go
+++ b/cmd/pgmanager/main.go
@@ -9,8 +9,8 @@ import (
 
 	// Packages
 	kong "github.com/alecthomas/kong"
-	httpclient "github.com/mutablelogic/go-pg/pkg/manager/httpclient"
 	client "github.com/mutablelogic/go-client"
+	httpclient "github.com/mutablelogic/go-pg/pkg/manager/httpclient"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -23,7 +23,7 @@ type Globals struct {
 	// HTTP server options
 	HTTP struct {
 		Prefix string `name:"prefix" help:"HTTP path prefix" default:"/api/v1"`
-		Listen string `name:"http" help:"HTTP Listen address" default:":8080"`
+		Addr   string `name:"addr" env:"PG_ADDR" help:"HTTP Listen address" default:":8080"`
 	} `embed:"" prefix:"http."`
 
 	// Private fields
@@ -44,6 +44,7 @@ type CLI struct {
 	SettingCommands
 	StatementCommands
 	TablespaceCommands
+	VersionCommands
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -68,7 +69,7 @@ func main() {
 // PRIVATE METHODS
 
 func (g *Globals) Client() (*httpclient.Client, error) {
-	host, port, err := net.SplitHostPort(g.HTTP.Listen)
+	host, port, err := net.SplitHostPort(g.HTTP.Addr)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/pgmanager/server.go
+++ b/cmd/pgmanager/server.go
@@ -92,12 +92,12 @@ func (cmd *RunServer) Run(ctx *Globals) error {
 	}
 
 	// Create a HTTP server
-	server, err := httpserver.New(ctx.HTTP.Listen, router, tlsconfig)
+	server, err := httpserver.New(ctx.HTTP.Addr, router, tlsconfig)
 	if err != nil {
 		return err
 	}
 
 	// Run the server
-	fmt.Println("Starting server on", ctx.HTTP.Listen)
+	fmt.Println("Starting server on", ctx.HTTP.Addr)
 	return server.Run(ctx.ctx)
 }

--- a/cmd/pgmanager/version.go
+++ b/cmd/pgmanager/version.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	// Packages
+	"github.com/mutablelogic/go-pg/pkg/version"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type VersionCommands struct {
+	Version VersionCommand `cmd:"version" help:"Print version information"`
+}
+
+type VersionCommand struct{}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+func (cmd *VersionCommand) Run(g *Globals) error {
+	if version.GitSource != "" {
+		fmt.Printf("%s@%s\n\n", version.GitSource, version.Version())
+	} else {
+		fmt.Printf("pgmanager %s\n\n", version.Version())
+	}
+	if version.GitHash != "" {
+		fmt.Printf("Commit: %s\n", version.GitHash)
+	}
+	if version.GitBranch != "" {
+		fmt.Printf("Branch: %s\n", version.GitBranch)
+	}
+	if version.GoBuildTime != "" {
+		fmt.Printf("Build Time: %s\n", version.GoBuildTime)
+	}
+	fmt.Printf("Compiler: %s\n", version.Compiler())
+	return nil
+}


### PR DESCRIPTION
This PR adds a version command to the pgmanager CLI tool and fixes the HTTP server address flag naming. The version command displays build information including Git source, commit hash, branch, build time, and compiler details. The HTTP flag was renamed from "http" to "addr" to make the command-line interface clearer (avoiding the redundant --http.http and providing the more intuitive --http.addr).

- Added version command that displays application version and build information
- Renamed HTTP flag from "Listen" to "Addr" with environment variable support (PG_ADDR)
- Minor import reordering for consistency