### PR TITLE
Added some dianostics

### DIFF
--- a/cmd/pgmanager/server.go
+++ b/cmd/pgmanager/server.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 
 	// Packages
-	"github.com/mutablelogic/go-pg"
-	"github.com/mutablelogic/go-pg/pkg/manager"
-	"github.com/mutablelogic/go-pg/pkg/manager/httphandler"
-	"github.com/mutablelogic/go-server/pkg/httpserver"
+	pg "github.com/mutablelogic/go-pg"
+	manager "github.com/mutablelogic/go-pg/pkg/manager"
+	httphandler "github.com/mutablelogic/go-pg/pkg/manager/httphandler"
+	version "github.com/mutablelogic/go-pg/pkg/version"
+	httpserver "github.com/mutablelogic/go-server/pkg/httpserver"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -93,6 +94,7 @@ func (cmd *RunServer) Run(ctx *Globals) error {
 	}
 
 	// Run the server
-	fmt.Println("Starting server on", ctx.HTTP.Addr)
+	fmt.Println(version.ExecName(), version.Version())
+	fmt.Println("Listening on", ctx.HTTP.Addr+ctx.HTTP.Prefix)
 	return server.Run(ctx.ctx)
 }

--- a/cmd/pgmanager/server.go
+++ b/cmd/pgmanager/server.go
@@ -23,6 +23,7 @@ type ServerCommands struct {
 
 type RunServer struct {
 	URL string `arg:"" name:"url" help:"Database URL" default:""`
+	UI  bool   `name:"ui" help:"Enable frontend UI" default:"false"`
 
 	// Postgres options
 	PG struct {
@@ -76,7 +77,7 @@ func (cmd *RunServer) Run(ctx *Globals) error {
 	// Register HTTP handlers
 	router := http.NewServeMux()
 	httphandler.RegisterBackendHandlers(router, ctx.HTTP.Prefix, manager)
-	httphandler.RegisterFrontendHandler(router, "")
+	httphandler.RegisterFrontendHandler(router, "", cmd.UI)
 
 	// Create a TLS config
 	var tlsconfig *tls.Config

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -76,16 +77,17 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
+	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/manager/httphandler/frontend_excluded.go
+++ b/pkg/manager/httphandler/frontend_excluded.go
@@ -10,7 +10,7 @@ import (
 )
 
 // RegisterFrontendHandler registers a fallback handler when frontend is not included
-func RegisterFrontendHandler(router *http.ServeMux, prefix string) {
+func RegisterFrontendHandler(router *http.ServeMux, prefix string, enabled bool) {
 	// Catch all handler returns a "not found" error
 	router.HandleFunc(joinPath(prefix, "/"), func(w http.ResponseWriter, r *http.Request) {
 		_ = httpresponse.Error(w, httpresponse.ErrNotFound, r.URL.String())

--- a/pkg/manager/httphandler/frontend_included.go
+++ b/pkg/manager/httphandler/frontend_included.go
@@ -8,13 +8,25 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+
+	// Packages
+	"github.com/mutablelogic/go-server/pkg/httpresponse"
 )
 
 //go:embed frontend/*
 var frontendFS embed.FS
 
-// RegisterFrontendHandler registers the frontend static file handler
-func RegisterFrontendHandler(router *http.ServeMux, prefix string) {
+// RegisterFrontendHandler registers the frontend static file handler if enabled,
+// otherwise registers a fallback handler that returns a not found error.
+func RegisterFrontendHandler(router *http.ServeMux, prefix string, enabled bool) {
+	if !enabled {
+		// Fallback handler returns a "not found" error
+		router.HandleFunc(joinPath(prefix, "/"), func(w http.ResponseWriter, r *http.Request) {
+			_ = httpresponse.Error(w, httpresponse.ErrNotFound, r.URL.String())
+		})
+		return
+	}
+
 	// Get the subdirectory to strip the "frontend" prefix
 	subFS, err := fs.Sub(frontendFS, "frontend")
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,10 @@
 package version
 
-import "runtime"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
 
 ///////////////////////////////////////////////////////////////////////////////
 // GLOBALS
@@ -15,6 +19,14 @@ var (
 
 ////////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
+
+func ExecName() string {
+	name, err := os.Executable()
+	if err != nil {
+		return "unknown"
+	}
+	return filepath.Base(name)
+}
 
 func Version() string {
 	if GitTag != "" {


### PR DESCRIPTION
This PR adds diagnostic output to the pgmanager server by introducing a new function to get the executable name and updating the server startup messages. However, there is a critical issue with dependency versions containing future dates.

- Added ExecName() function to retrieve the executable name
- Updated server startup output to display executable name, version, and full listening address