### PR TITLE
Removed ID from span name

### DIFF
--- a/pkg/queue/run.go
+++ b/pkg/queue/run.go
@@ -213,7 +213,7 @@ func (manager *Manager) runTaskWorker(ctx context.Context, task *schema.Task, tr
 	defer cancel()
 
 	// Create the span
-	child2, endfunc := otel.StartSpan(tracer, child, spanManagerName("task."+fmt.Sprint(task.Queue, ".", task.Id)),
+	child2, endfunc := otel.StartSpan(tracer, child, spanManagerName("task."+task.Queue),
 		attribute.String("task", task.String()),
 	)
 	defer func() { endfunc(result) }()


### PR DESCRIPTION
This PR improves OpenTelemetry span naming by removing the task ID from the span name while retaining it in span attributes.

Changes:
- Modified span name from "task.{queue}.{id}" to "task.{queue}" to reduce span cardinality
- Aligns task span naming with ticker span naming pattern for consistency
