### PR TITLE
Djt/0111/spanname

### DIFF
--- a/pkg/queue/run.go
+++ b/pkg/queue/run.go
@@ -213,7 +213,7 @@ func (manager *Manager) runTaskWorker(ctx context.Context, task *schema.Task, tr
 	defer cancel()
 
 	// Create the span
-	child2, endfunc := otel.StartSpan(tracer, child, spanManagerName("task."+fmt.Sprint(task.Queue, ".", task.Id)),
+	child2, endfunc := otel.StartSpan(tracer, child, spanManagerName("task."+task.Queue),
 		attribute.String("task", task.String()),
 	)
 	defer func() { endfunc(result) }()


### PR DESCRIPTION
This pull request modifies task execution and error handling in the queue manager. The changes simplify span naming and add status checking after task release, but contain critical bugs that need to be addressed.

Changes:

Simplified OpenTelemetry span names for tasks by removing individual task IDs
Added error logging for failed tasks in the task loop
Added status checking after task release to detect non-"released" states
