### PR TITLE
Reshape Subscribe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ the transaction will be committed. Transactions can be nested.
 
 ## Notify and Listen
 
-PostgreSQL supports asynchronous notifications via `NOTIFY` and `LISTEN`. The preferred API is `Subscribe`, which acquires a dedicated listener connection from the pool, invokes a callback for each notification, and automatically unsubscribes when the context is cancelled or the pool is closed.
+PostgreSQL supports asynchronous notifications via `NOTIFY` and `LISTEN`. The preferred API is `Subscribe`, which acquires a dedicated listener connection from the pool, returns a notification channel, and automatically unsubscribes when the context is cancelled or the pool is closed.
 
 ```go
 import (
@@ -412,11 +412,13 @@ import (
 )
 
 // Subscribe to a channel using a pool-backed connection.
-if err := pool.Subscribe(ctx, "my_channel", func(_ context.Context, n pg.Notification) error {
-  fmt.Printf("Channel: %s, Payload: %s\n", n.Channel, n.Payload)
-  return nil
-}); err != nil {
+notifications, err := pool.Subscribe(ctx, "my_channel")
+if err != nil {
   panic(err)
+}
+
+for n := range notifications {
+  fmt.Printf("Channel: %s, Payload: %s\n", n.Channel, n.Payload)
 }
 
 // Block until shutdown.
@@ -425,7 +427,7 @@ if err := pool.Subscribe(ctx, "my_channel", func(_ context.Context, n pg.Notific
 
 Subscriptions are long-lived and tied to a dedicated PostgreSQL session, so they are only supported on pool-backed connections. Calling `Subscribe` from a transactional or bulk connection returns `pg.ErrNotAvailable`.
 
-`Subscribe` returns setup errors only. After registration, the subscription runs in the background and stops if the callback returns an error or if the listener encounters a non-context error such as a dropped connection. The callback receives a context that is cancelled when the subscription is shutting down.
+`Subscribe` returns setup errors only. After registration, the subscription runs in the background and closes the returned channel if the context is cancelled or if the listener encounters an error such as a dropped connection.
 
 When `pool.Close()` is called, all active subscriptions are cancelled and the pool waits for their callbacks to exit before returning.
 

--- a/README.md
+++ b/README.md
@@ -417,19 +417,24 @@ if err != nil {
   panic(err)
 }
 
-for n := range notifications {
-  fmt.Printf("Channel: %s, Payload: %s\n", n.Channel, n.Payload)
+for {
+  select {
+  case <-ctx.Done():
+    return
+  case n, ok := <-notifications:
+    if !ok {
+      return
+    }
+    fmt.Printf("Channel: %s, Payload: %s\n", n.Channel, n.Payload)
+  }
 }
-
-// Block until shutdown.
-<-ctx.Done()
 ```
 
 Subscriptions are long-lived and tied to a dedicated PostgreSQL session, so they are only supported on pool-backed connections. Calling `Subscribe` from a transactional or bulk connection returns `pg.ErrNotAvailable`.
 
 `Subscribe` returns setup errors only. After registration, the subscription runs in the background and closes the returned channel if the context is cancelled or if the listener encounters an error such as a dropped connection.
 
-When `pool.Close()` is called, all active subscriptions are cancelled and the pool waits for their callbacks to exit before returning.
+When `pool.Close()` is called, all active subscriptions are cancelled and the pool waits for their listener goroutines to exit and channels to close before returning.
 
 To send a notification from another connection:
 

--- a/bulk.go
+++ b/bulk.go
@@ -46,8 +46,8 @@ func (conn *bulkconn) Bulk(context.Context, func(Conn) error) error {
 }
 
 // Subscribe is not supported for bulk connections.
-func (conn *bulkconn) Subscribe(context.Context, string, func(context.Context, Notification) error) error {
-	return ErrNotAvailable.With("subscribe requires pool-backed connection")
+func (conn *bulkconn) Subscribe(context.Context, string) (<-chan Notification, error) {
+	return nil, ErrNotAvailable.With("subscribe requires pool-backed connection")
 }
 
 // Execute a query

--- a/conn.go
+++ b/conn.go
@@ -30,12 +30,10 @@ type Conn interface {
 
 	// Subscribe to a PostgreSQL notification channel. Subscribe returns setup
 	// errors only; after successful registration the subscription runs in the
-	// background. The callback is invoked serially for each payload with a
-	// context that is cancelled when the subscription stops. The subscription
-	// runs until the context is cancelled, the pool is closed, the callback
-	// returns an error, or the listener stops because WaitForNotification
-	// returns a non-context error such as a dropped connection.
-	Subscribe(context.Context, string, func(context.Context, Notification) error) error
+	// background and delivers notifications on the returned channel. The channel
+	// is closed when the context is cancelled, the pool is closed, or the
+	// listener stops because WaitForNotification returns an error.
+	Subscribe(context.Context, string) (<-chan Notification, error)
 
 	// Execute a query
 	Exec(context.Context, string) error
@@ -161,8 +159,8 @@ func (p *conn) Bulk(ctx context.Context, fn func(Conn) error) error {
 
 // Subscribe requires a pool-backed connection so the listener lifecycle can be
 // managed independently of transactions.
-func (p *conn) Subscribe(context.Context, string, func(context.Context, Notification) error) error {
-	return ErrNotAvailable.With("subscribe requires pool-backed connection")
+func (p *conn) Subscribe(context.Context, string) (<-chan Notification, error) {
+	return nil, ErrNotAvailable.With("subscribe requires pool-backed connection")
 }
 
 // Execute a query

--- a/listener.go
+++ b/listener.go
@@ -106,8 +106,8 @@ func subscribe(ctx context.Context, pg *poolconn, channel string) (<-chan Notifi
 	notifyCh := make(chan Notification)
 
 	go func() {
-		defer close(notifyCh)
 		defer sub.Done()
+		defer close(notifyCh)
 		defer pg.conn.removeSubscription(sub)
 		defer cancel()
 		defer func() {

--- a/listener.go
+++ b/listener.go
@@ -83,31 +83,30 @@ func (l *listener) Close(ctx context.Context) error {
 ////////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
 
-func subscribe(ctx context.Context, pg *poolconn, channel string, fn func(context.Context, Notification) error) error {
+func subscribe(ctx context.Context, pg *poolconn, channel string) (<-chan Notification, error) {
 	channel = strings.TrimSpace(channel)
 	if channel == "" {
-		return ErrBadParameter.With("channel is required")
-	}
-	if fn == nil {
-		return ErrBadParameter.With("callback is required")
+		return nil, ErrBadParameter.With("channel is required")
 	}
 
 	listener := pg.Listener()
 	if listener == nil {
-		return ErrNotAvailable.With("subscriptions are unavailable")
+		return nil, ErrNotAvailable.With("subscriptions are unavailable")
 	}
 	if err := listener.Listen(ctx, channel); err != nil {
-		return err
+		return nil, errors.Join(err, closeListener(listener))
 	}
 
 	runCtx, cancel := context.WithCancel(ctx)
 	sub, err := pg.conn.addSubscription(cancel)
 	if err != nil {
 		cancel()
-		return errors.Join(err, cleanupListener(listener, channel))
+		return nil, errors.Join(err, cleanupListener(listener, channel))
 	}
+	notifyCh := make(chan Notification)
 
 	go func() {
+		defer close(notifyCh)
 		defer sub.Done()
 		defer pg.conn.removeSubscription(sub)
 		defer cancel()
@@ -123,13 +122,15 @@ func subscribe(ctx context.Context, pg *poolconn, channel string, fn func(contex
 				}
 				return
 			}
-			if err := fn(runCtx, *n); err != nil {
+			select {
+			case notifyCh <- *n:
+			case <-runCtx.Done():
 				return
 			}
 		}
 	}()
 
-	return nil
+	return notifyCh, nil
 }
 
 func cleanupListener(listener Listener, channel string) error {
@@ -138,6 +139,13 @@ func cleanupListener(listener Listener, channel string) error {
 
 	err := listener.Unlisten(ctx, channel)
 	return errors.Join(err, listener.Close(ctx))
+}
+
+func closeListener(listener Listener) error {
+	ctx, cancel := context.WithTimeout(context.Background(), subscriptionCleanupTimeout)
+	defer cancel()
+
+	return listener.Close(ctx)
 }
 
 // Connect to the database, and listen to a topic

--- a/pkg/broadcaster/README.md
+++ b/pkg/broadcaster/README.md
@@ -1,0 +1,101 @@
+# PostgreSQL Broadcaster
+
+The broadcaster package wraps PostgreSQL `LISTEN` and `NOTIFY` and fans decoded JSON notifications out to multiple Go callbacks.
+
+The current implementation subscribes to a PostgreSQL channel via `pg.Conn.Subscribe`, decodes each payload as JSON, and delivers it to every active subscriber until either the subscriber context or broadcaster context is canceled.
+
+The package decodes each payload into `broadcaster.ChangeNotification`, so the SQL payload needs to look like this:
+
+```json
+{"schema":"auth","table":"user","action":"INSERT"}
+```
+
+## PostgreSQL Trigger Function
+
+One practical way to drive the broadcaster is with a trigger function that emits a JSON payload whenever an `INSERT`, `UPDATE`, `TRUNCATE`, or `DELETE` occurs on a table.
+
+```sql
+CREATE OR REPLACE FUNCTION app.notify_table()
+RETURNS trigger AS $$
+DECLARE
+    lock_id BIGINT;
+BEGIN
+    lock_id := hashtextextended(TG_TABLE_SCHEMA || '.' || TG_TABLE_NAME, 0);
+    IF pg_try_advisory_xact_lock(lock_id) THEN
+        PERFORM pg_notify(
+            'backend.table_change',
+            json_build_object(
+                'schema', TG_TABLE_SCHEMA,
+                'table', TG_TABLE_NAME,
+                'action', TG_OP
+            )::text
+        );
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+Attach it to a table with a statement-level trigger:
+
+```sql
+DROP TRIGGER IF EXISTS user_table_changes_notify ON app_user;
+
+CREATE TRIGGER user_table_changes_notify
+AFTER INSERT OR UPDATE OR TRUNCATE OR DELETE ON app_user
+FOR EACH STATEMENT
+EXECUTE FUNCTION app.notify_table();
+```
+
+The advisory lock suppresses repeated notifications for the same table within a transaction, which is useful when a single statement touches multiple rows.
+
+## Go Example
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "os/signal"
+    "syscall"
+
+    broadcaster "github.com/mutablelogic/go-pg/pkg/broadcaster"
+    pg "github.com/mutablelogic/go-pg"
+)
+
+func main() {
+    ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+    defer stop()
+
+    pool, err := pg.NewPool(ctx,
+        pg.WithURL("postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable"),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer pool.Close()
+
+    b, err := broadcaster.NewBroadcaster(pool, "backend.table_change")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer b.Close()
+
+    err = b.Subscribe(ctx, func(change broadcaster.ChangeNotification) {
+        log.Printf("table change: schema=%s table=%s action=%s", change.Schema, change.Table, change.Action)
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    <-ctx.Done()
+}
+```
+
+## Notes
+
+- Notifications with invalid JSON payloads are ignored.
+- Each subscriber gets its own buffered channel so slow callbacks do not immediately block the PostgreSQL listener.
+- `Close` cancels the listener and waits for subscriber goroutines to exit.
+- If you want a different payload shape, keep the same `LISTEN`/`NOTIFY` pattern and adapt the JSON type decoded by the broadcaster package.

--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -1,0 +1,145 @@
+package broadcaster
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"sync"
+
+	// Packages
+	pg "github.com/mutablelogic/go-pg"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// Broadcaster delivers decoded change notifications to callbacks until the
+// subscriber context or broadcaster lifetime ends.
+type Broadcaster interface {
+	Subscribe(context.Context, func(ChangeNotification)) error
+}
+
+type subscription struct {
+	ch   chan ChangeNotification
+	done chan struct{}
+}
+
+type broadcaster struct {
+	mu          sync.RWMutex
+	subscribers []*subscription
+	wg          sync.WaitGroup
+	ctx         context.Context
+	cancel      context.CancelFunc
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+func NewBroadcaster(conn pg.Conn, channel string) (*broadcaster, error) {
+	self := new(broadcaster)
+
+	// Set up the context and done channel
+	ctx, cancel := context.WithCancel(context.Background())
+	self.ctx = ctx
+	self.cancel = cancel
+
+	// Subscribe to the PostgreSQL channel
+	notifications, err := conn.Subscribe(ctx, channel)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	// Respond to notifications in a separate goroutine
+	self.wg.Add(1)
+	go func() {
+		defer self.wg.Done()
+		for notification := range notifications {
+			var change ChangeNotification
+			// Skip any bad JSON
+			if err := json.Unmarshal(notification.Payload, &change); err != nil {
+				continue
+			}
+			self.broadcast(change)
+		}
+	}()
+
+	// Return success
+	return self, nil
+}
+
+func (b *broadcaster) Close() {
+	b.cancel()
+	b.wg.Wait()
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+func (b *broadcaster) Subscribe(ctx context.Context, callback func(ChangeNotification)) error {
+	// Create a new channel for this subscriber
+	subscriber := &subscription{
+		ch:   make(chan ChangeNotification, 10), // Buffered channel to avoid blocking
+		done: make(chan struct{}),
+	}
+
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, subscriber)
+	b.mu.Unlock()
+
+	// Start a goroutine to listen for notifications and call the callback
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		defer b.unsubscribe(subscriber)
+		for {
+			select {
+			case change := <-subscriber.ch:
+				callback(change)
+			case <-ctx.Done():
+				return
+			case <-b.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS
+
+func (b *broadcaster) broadcast(change ChangeNotification) {
+	b.mu.RLock()
+	subscribers := slices.Clone(b.subscribers)
+	b.mu.RUnlock()
+
+	for _, subscriber := range subscribers {
+		// Skip subscribers that were removed after the snapshot was taken.
+		select {
+		case <-subscriber.done:
+			continue
+		default:
+		}
+
+		// Deliver the change unless the subscriber or broadcaster has been canceled.
+		select {
+		case subscriber.ch <- change:
+		case <-subscriber.done:
+		case <-b.ctx.Done():
+			return
+		}
+	}
+}
+
+func (b *broadcaster) unsubscribe(subscriber *subscription) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Remove the subscriber and signal any in-flight broadcasts to skip it.
+	if i := slices.Index(b.subscribers, subscriber); i >= 0 {
+		close(subscriber.done)
+		b.subscribers = slices.Delete(b.subscribers, i, i+1)
+	}
+}

--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -77,6 +77,10 @@ func (b *broadcaster) Close() {
 // PUBLIC METHODS
 
 func (b *broadcaster) Subscribe(ctx context.Context, callback func(ChangeNotification)) error {
+	if callback == nil {
+		return pg.ErrBadParameter.With("callback is required")
+	}
+
 	// Create a new channel for this subscriber
 	subscriber := &subscription{
 		ch:   make(chan ChangeNotification, 10), // Buffered channel to avoid blocking
@@ -112,21 +116,12 @@ func (b *broadcaster) Subscribe(ctx context.Context, callback func(ChangeNotific
 
 func (b *broadcaster) broadcast(change ChangeNotification) {
 	b.mu.RLock()
-	subscribers := slices.Clone(b.subscribers)
-	b.mu.RUnlock()
+	defer b.mu.RUnlock()
 
-	for _, subscriber := range subscribers {
-		// Skip subscribers that were removed after the snapshot was taken.
-		select {
-		case <-subscriber.done:
-			continue
-		default:
-		}
-
-		// Deliver the change unless the subscriber or broadcaster has been canceled.
+	// Deliver the change unless the broadcaster has been canceled.
+	for _, subscriber := range b.subscribers {
 		select {
 		case subscriber.ch <- change:
-		case <-subscriber.done:
 		case <-b.ctx.Done():
 			return
 		}

--- a/pkg/broadcaster/broadcaster_test.go
+++ b/pkg/broadcaster/broadcaster_test.go
@@ -1,0 +1,262 @@
+package broadcaster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	// Packages
+	test "github.com/mutablelogic/go-pg/pkg/test"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// GLOBALS
+
+var conn test.Conn
+
+///////////////////////////////////////////////////////////////////////////////
+// TEST MAIN
+
+func TestMain(m *testing.M) {
+	test.Main(m, &conn)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// HELPERS
+
+func newTestBroadcaster(t *testing.T) *broadcaster {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b := &broadcaster{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	t.Cleanup(b.Close)
+
+	return b
+}
+
+func waitForSubscriberCount(t *testing.T, b *broadcaster, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		b.mu.RLock()
+		got := len(b.subscribers)
+		b.mu.RUnlock()
+
+		if got == want {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	b.mu.RLock()
+	got := len(b.subscribers)
+	b.mu.RUnlock()
+	t.Fatalf("subscriber count = %d, want %d", got, want)
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// UNIT TESTS
+
+func TestChangeNotification_String(t *testing.T) {
+	assert := assert.New(t)
+
+	value := ChangeNotification{
+		Schema: "auth",
+		Table:  "user",
+		Action: "INSERT",
+	}
+
+	assert.Equal("{\n  \"schema\": \"auth\",\n  \"table\": \"user\",\n  \"action\": \"INSERT\"\n}", value.String())
+}
+
+func TestBroadcaster_SubscribeAndBroadcast(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	b := newTestBroadcaster(t)
+
+	first := make(chan ChangeNotification, 1)
+	second := make(chan ChangeNotification, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(b.Subscribe(ctx, func(change ChangeNotification) {
+		first <- change
+	}))
+	require.NoError(b.Subscribe(ctx, func(change ChangeNotification) {
+		second <- change
+	}))
+
+	change := ChangeNotification{Schema: "public", Table: "widget", Action: "UPDATE"}
+	b.broadcast(change)
+
+	select {
+	case got := <-first:
+		assert.Equal(change, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for first subscriber")
+	}
+
+	select {
+	case got := <-second:
+		assert.Equal(change, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for second subscriber")
+	}
+}
+
+func TestBroadcaster_UnsubscribeRemovesCanceledSubscriber(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	b := newTestBroadcaster(t)
+
+	staleCtx, staleCancel := context.WithCancel(context.Background())
+	activeCtx, activeCancel := context.WithCancel(context.Background())
+	defer activeCancel()
+
+	active := make(chan ChangeNotification, 1)
+
+	require.NoError(b.Subscribe(staleCtx, func(ChangeNotification) {}))
+	require.NoError(b.Subscribe(activeCtx, func(change ChangeNotification) {
+		active <- change
+	}))
+	waitForSubscriberCount(t, b, 2)
+
+	staleCancel()
+	waitForSubscriberCount(t, b, 1)
+
+	change := ChangeNotification{Schema: "public", Table: "widget", Action: "DELETE"}
+	b.broadcast(change)
+
+	select {
+	case got := <-active:
+		assert.Equal(change, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for active subscriber")
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// INTEGRATION TESTS
+
+func TestBroadcaster_Integration_DeliversDecodedChange(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conn := conn.Begin(t)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	channel := fmt.Sprintf("test_broadcaster_delivers_%d", time.Now().UnixNano())
+	b, err := NewBroadcaster(conn, channel)
+	require.NoError(err)
+	defer b.Close()
+
+	changes := make(chan ChangeNotification, 1)
+	require.NoError(b.Subscribe(ctx, func(change ChangeNotification) {
+		select {
+		case changes <- change:
+		default:
+		}
+	}))
+
+	payload := `{"schema":"auth","table":"user","action":"INSERT"}`
+	require.NoError(conn.Exec(context.Background(), fmt.Sprintf("SELECT pg_notify('%s', '%s')", channel, payload)))
+
+	select {
+	case change := <-changes:
+		assert.Equal("auth", change.Schema)
+		assert.Equal("user", change.Table)
+		assert.Equal("INSERT", change.Action)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for notification")
+	}
+}
+
+func TestBroadcaster_Integration_BroadcastsToAllSubscribers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conn := conn.Begin(t)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	channel := fmt.Sprintf("test_broadcaster_broadcasts_%d", time.Now().UnixNano())
+	b, err := NewBroadcaster(conn, channel)
+	require.NoError(err)
+	defer b.Close()
+
+	first := make(chan ChangeNotification, 1)
+	second := make(chan ChangeNotification, 1)
+
+	require.NoError(b.Subscribe(ctx, func(change ChangeNotification) {
+		select {
+		case first <- change:
+		default:
+		}
+	}))
+	require.NoError(b.Subscribe(ctx, func(change ChangeNotification) {
+		select {
+		case second <- change:
+		default:
+		}
+	}))
+
+	payload := `{"schema":"auth","table":"group","action":"UPDATE"}`
+	require.NoError(conn.Exec(context.Background(), fmt.Sprintf("SELECT pg_notify('%s', '%s')", channel, payload)))
+
+	select {
+	case change := <-first:
+		assert.Equal("group", change.Table)
+		assert.Equal("UPDATE", change.Action)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for first subscriber")
+	}
+
+	select {
+	case change := <-second:
+		assert.Equal("group", change.Table)
+		assert.Equal("UPDATE", change.Action)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for second subscriber")
+	}
+}
+
+func TestBroadcaster_Integration_IgnoresInvalidJSON(t *testing.T) {
+	require := require.New(t)
+	conn := conn.Begin(t)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	defer cancel()
+
+	channel := fmt.Sprintf("test_broadcaster_invalid_%d", time.Now().UnixNano())
+	b, err := NewBroadcaster(conn, channel)
+	require.NoError(err)
+	defer b.Close()
+
+	changes := make(chan ChangeNotification, 1)
+	require.NoError(b.Subscribe(ctx, func(change ChangeNotification) {
+		select {
+		case changes <- change:
+		default:
+		}
+	}))
+
+	require.NoError(conn.Exec(context.Background(), fmt.Sprintf("SELECT pg_notify('%s', 'not-json')", channel)))
+
+	select {
+	case change := <-changes:
+		t.Fatalf("unexpected change received: %v", change)
+	case <-ctx.Done():
+	}
+}

--- a/pkg/broadcaster/broadcaster_test.go
+++ b/pkg/broadcaster/broadcaster_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	// Packages
+	pg "github.com/mutablelogic/go-pg"
 	test "github.com/mutablelogic/go-pg/pkg/test"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
@@ -110,6 +111,14 @@ func TestBroadcaster_SubscribeAndBroadcast(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for second subscriber")
 	}
+}
+
+func TestBroadcaster_SubscribeNilCallback(t *testing.T) {
+	require := require.New(t)
+	b := newTestBroadcaster(t)
+
+	err := b.Subscribe(context.Background(), nil)
+	require.ErrorIs(err, pg.ErrBadParameter)
 }
 
 func TestBroadcaster_UnsubscribeRemovesCanceledSubscriber(t *testing.T) {

--- a/pkg/broadcaster/schema.go
+++ b/pkg/broadcaster/schema.go
@@ -1,0 +1,22 @@
+package broadcaster
+
+import "encoding/json"
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// ChangeNotification is emitted for table changes when PostgreSQL NOTIFY
+// payloads match the broadcaster JSON schema.
+type ChangeNotification struct {
+	Schema string `json:"schema"`
+	Table  string `json:"table"`
+	Action string `json:"action"`
+}
+
+func (n ChangeNotification) String() string {
+	data, err := json.MarshalIndent(n, "", "  ")
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}

--- a/pool.go
+++ b/pool.go
@@ -155,9 +155,9 @@ func (p *poolconn) Bulk(ctx context.Context, fn func(conn Conn) error) error {
 
 // Subscribe to a PostgreSQL notification channel using a dedicated connection.
 // Subscribe returns only initial registration errors; runtime listener errors
-// terminate the background subscription.
-func (p *poolconn) Subscribe(ctx context.Context, channel string, fn func(context.Context, Notification) error) error {
-	return subscribe(ctx, p, channel, fn)
+// terminate the background subscription and close the returned channel.
+func (p *poolconn) Subscribe(ctx context.Context, channel string) (<-chan Notification, error) {
+	return subscribe(ctx, p, channel)
 }
 
 // Execute a query

--- a/pool_test.go
+++ b/pool_test.go
@@ -143,30 +143,32 @@ func Test_Pool_004(t *testing.T) {
 	defer cancel()
 
 	channel := fmt.Sprintf("test_pool_subscribe_%d", time.Now().UnixNano())
-	notifyCh := make(chan pg.Notification, 1)
-
-	require.NoError(conn.Subscribe(ctx, channel, func(subCtx context.Context, n pg.Notification) error {
-		require.NoError(subCtx.Err())
-		notifyCh <- pg.Notification{Channel: n.Channel, Payload: append([]byte(nil), n.Payload...)}
-		return nil
-	}))
+	notifyCh, err := conn.Subscribe(ctx, channel)
+	require.NoError(err)
 	require.NoError(conn.Exec(context.Background(), fmt.Sprintf("SELECT pg_notify('%s', 'hello')", channel)))
 
 	select {
-	case notify := <-notifyCh:
+	case notify, ok := <-notifyCh:
+		if !ok {
+			t.Fatal("subscription channel closed before notification")
+		}
 		assert.Equal(channel, notify.Channel)
 		assert.Equal([]byte("hello"), notify.Payload)
 	case <-ctx.Done():
 		t.Fatal("timeout waiting for notification")
 	}
 
-	require.ErrorIs(conn.Tx(context.Background(), func(tx pg.Conn) error {
-		return tx.Subscribe(context.Background(), channel, func(context.Context, pg.Notification) error { return nil })
-	}), pg.ErrNotAvailable)
+	err = conn.Tx(context.Background(), func(tx pg.Conn) error {
+		_, err := tx.Subscribe(context.Background(), channel)
+		return err
+	})
+	require.ErrorIs(err, pg.ErrNotAvailable)
 
-	require.ErrorIs(conn.Bulk(context.Background(), func(tx pg.Conn) error {
-		return tx.Subscribe(context.Background(), channel, func(context.Context, pg.Notification) error { return nil })
-	}), pg.ErrNotAvailable)
+	err = conn.Bulk(context.Background(), func(tx pg.Conn) error {
+		_, err := tx.Subscribe(context.Background(), channel)
+		return err
+	})
+	require.ErrorIs(err, pg.ErrNotAvailable)
 }
 
 func Test_Pool_005(t *testing.T) {
@@ -183,22 +185,20 @@ func Test_Pool_005(t *testing.T) {
 	channel := fmt.Sprintf("test_pool_close_%d", time.Now().UnixNano())
 	started := make(chan struct{})
 	closingStarted := make(chan struct{})
-	cancelled := make(chan struct{})
 	closed := make(chan struct{})
+	notifyCh, err := pool.Subscribe(context.Background(), channel)
+	require.NoError(err)
 
-	require.NoError(pool.Subscribe(context.Background(), channel, func(subCtx context.Context, n pg.Notification) error {
-		require.NoError(subCtx.Err())
-		require.Equal(channel, n.Channel)
-		require.Equal([]byte("hello"), n.Payload)
-		close(started)
-		<-subCtx.Done()
-		close(cancelled)
-		return subCtx.Err()
-	}))
 	require.NoError(pool.Exec(context.Background(), fmt.Sprintf("SELECT pg_notify('%s', 'hello')", channel)))
 
 	select {
-	case <-started:
+	case notify, ok := <-notifyCh:
+		if !ok {
+			t.Fatal("subscription channel closed before notification")
+		}
+		require.Equal(channel, notify.Channel)
+		require.Equal([]byte("hello"), notify.Payload)
+		close(started)
 	case <-ctx.Done():
 		t.Fatal("timeout waiting for callback")
 	}
@@ -216,9 +216,12 @@ func Test_Pool_005(t *testing.T) {
 	}
 
 	select {
-	case <-cancelled:
+	case _, ok := <-notifyCh:
+		if ok {
+			t.Fatal("subscription channel remained open after pool close")
+		}
 	case <-ctx.Done():
-		t.Fatal("timeout waiting for callback cancellation")
+		t.Fatal("timeout waiting for subscription channel to close")
 	}
 
 	select {


### PR DESCRIPTION
This pull request refactors the PostgreSQL `Subscribe` API to simplify its usage by removing the callback-based interface in favor of returning a channel of notifications. This makes it easier for users to consume notifications using Go channels and aligns the API with idiomatic Go practices. The documentation and tests are updated accordingly.

**API changes and improvements:**

* The `Subscribe` method on `Conn` and related types now returns a `<-chan Notification` and an `error`, instead of taking a callback function. The channel is closed when the subscription ends. [[1]](diffhunk://#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654L33-R36) [[2]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L158-R160) [[3]](diffhunk://#diff-a54eded1944e2edd2effceb304464b1818a393c21bfc71c2ac781e72ca54ab3bL49-R50)
* The internal `subscribe` function and its callers are updated to implement the new channel-based approach and remove the callback logic. [[1]](diffhunk://#diff-52136e2f401dea328d50069c304fe222eb004d0ca7b8b12e6e6c4adbc9df6979L86-R109) [[2]](diffhunk://#diff-52136e2f401dea328d50069c304fe222eb004d0ca7b8b12e6e6c4adbc9df6979L126-R133)

**Documentation updates:**

* The `README.md` is updated to describe the new channel-based subscription API and provide an example of using the returned channel to receive notifications. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L404-R404) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L415-R430)

**Test updates:**

* All tests using the old callback-based `Subscribe` API are refactored to use the new channel-based approach, including checks for correct notification delivery and channel closure. [[1]](diffhunk://#diff-080f4afaab90af50165762eb8438f21979a427a42f7cb821c0ccf192fd3afa98L146-R171) [[2]](diffhunk://#diff-080f4afaab90af50165762eb8438f21979a427a42f7cb821c0ccf192fd3afa98L186-R201) [[3]](diffhunk://#diff-080f4afaab90af50165762eb8438f21979a427a42f7cb821c0ccf192fd3afa98L219-R224)

**Error handling improvements:**

* Improved error handling when cleaning up listeners and subscriptions, including a new `closeListener` helper for proper resource cleanup.

These changes modernize the notification subscription interface, making it more ergonomic and idiomatic for Go developers.