### PR TITLE
Added additional test options for integration testing

### DIFF
--- a/pkg/test/opt.go
+++ b/pkg/test/opt.go
@@ -15,6 +15,7 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 // TYPES
 
+// Opt mutates a container request before it is started.
 type Opt func(*opts) error
 
 type opts struct {
@@ -24,6 +25,7 @@ type opts struct {
 ////////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
 
+// OptCommand sets the container command.
 func OptCommand(cmd []string) Opt {
 	return func(o *opts) error {
 		o.req.Cmd = cmd
@@ -31,6 +33,15 @@ func OptCommand(cmd []string) Opt {
 	}
 }
 
+// OptEntrypoint sets the container entrypoint.
+func OptEntrypoint(entrypoint ...string) Opt {
+	return func(o *opts) error {
+		o.req.Entrypoint = entrypoint
+		return nil
+	}
+}
+
+// OptEnv sets a single container environment variable.
 func OptEnv(name, value string) Opt {
 	return func(o *opts) error {
 		if o.req.Env == nil {
@@ -41,6 +52,7 @@ func OptEnv(name, value string) Opt {
 	}
 }
 
+// OptPorts exposes one or more container ports and waits for an exposed port.
 func OptPorts(ports ...string) Opt {
 	return func(o *opts) error {
 		o.req.ExposedPorts = ports
@@ -49,6 +61,36 @@ func OptPorts(ports ...string) Opt {
 	}
 }
 
+// OptFile copies a single file into the container before startup.
+func OptFile(file testcontainers.ContainerFile) Opt {
+	return func(o *opts) error {
+		o.req.Files = append(o.req.Files, file)
+		return nil
+	}
+}
+
+// OptFiles copies multiple files into the container before startup.
+func OptFiles(files ...testcontainers.ContainerFile) Opt {
+	return func(o *opts) error {
+		o.req.Files = append(o.req.Files, files...)
+		return nil
+	}
+}
+
+// OptWait appends a custom wait strategy to the container request.
+func OptWait(strategy wait.Strategy) Opt {
+	return func(o *opts) error {
+		o.appendWaitStrategy(strategy)
+		return nil
+	}
+}
+
+// OptWaitLog waits for a specific log line before considering the container ready.
+func OptWaitLog(log string) Opt {
+	return OptWait(wait.ForLog(log))
+}
+
+// OptPostgres configures a PostgreSQL container and adds SQL readiness checks.
 func OptPostgres(user, password, database string) Opt {
 	return func(o *opts) error {
 		if err := OptEnv("POSTGRES_USER", user)(o); err != nil {
@@ -81,6 +123,7 @@ func OptPostgresSetting(key, value string) Opt {
 ////////////////////////////////////////////////////////////////////////////////
 // PRIVATE METHODS
 
+// appendWaitStrategy merges a wait strategy into the current request.
 func (o *opts) appendWaitStrategy(strategy wait.Strategy) {
 	if o.req.WaitingFor == nil {
 		o.req.WaitingFor = strategy

--- a/pkg/test/opt_test.go
+++ b/pkg/test/opt_test.go
@@ -1,0 +1,65 @@
+package test
+package test
+
+import (
+	"strings"
+	"testing"
+
+	// Packages
+	nat "github.com/docker/go-connections/nat"
+	testcontainers "github.com/testcontainers/testcontainers-go"
+	wait "github.com/testcontainers/testcontainers-go/wait"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+)
+
+func Test_Opt_001(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	o := opts{req: testcontainers.ContainerRequest{WaitingFor: wait.ForAll()}}
+
+	require.NoError(OptEntrypoint("/bin/sh", "-c")(&o))
+	require.NoError(OptCommand([]string{"echo", "hello"})(&o))
+	require.NoError(OptEnv("A", "1")(&o))
+	require.NoError(OptPorts("3389/tcp")(&o))
+	require.NoError(OptFile(testcontainers.ContainerFile{
+		Reader:            strings.NewReader("echo bootstrap\n"),
+		ContainerFilePath: "/bootstrap.sh",
+		FileMode:          0o755,
+	})(&o))
+	require.NoError(OptWait(wait.ForListeningPort(nat.Port("3389/tcp")))(&o))
+	require.NoError(OptWaitLog("server ready")(&o))
+
+	assert.Equal([]string{"/bin/sh", "-c"}, o.req.Entrypoint)
+	assert.Equal([]string{"echo", "hello"}, o.req.Cmd)
+	assert.Equal("1", o.req.Env["A"])
+	assert.Equal([]string{"3389/tcp"}, o.req.ExposedPorts)
+	if assert.Len(o.req.Files, 1) {
+		assert.Equal("/bootstrap.sh", o.req.Files[0].ContainerFilePath)
+		assert.Equal(int64(0o755), o.req.Files[0].FileMode)
+	}
+
+	multi, ok := o.req.WaitingFor.(*wait.MultiStrategy)
+	require.True(ok)
+	assert.Len(multi.Strategies, 3)
+	assert.IsType(wait.ForExposedPort(), multi.Strategies[0])
+	assert.IsType(wait.ForListeningPort(nat.Port("3389/tcp")), multi.Strategies[1])
+	assert.IsType(wait.ForLog("server ready"), multi.Strategies[2])
+}
+
+func Test_Opt_002(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	o := opts{req: testcontainers.ContainerRequest{WaitingFor: wait.ForAll()}}
+	require.NoError(OptFiles(
+		testcontainers.ContainerFile{ContainerFilePath: "/one", FileMode: 0o644},
+		testcontainers.ContainerFile{ContainerFilePath: "/two", FileMode: 0o600},
+	)(&o))
+
+	if assert.Len(o.req.Files, 2) {
+		assert.Equal("/one", o.req.Files[0].ContainerFilePath)
+		assert.Equal("/two", o.req.Files[1].ContainerFilePath)
+	}
+}

--- a/pkg/test/opt_test.go
+++ b/pkg/test/opt_test.go
@@ -1,5 +1,4 @@
 package test
-package test
 
 import (
 	"strings"
@@ -7,10 +6,10 @@ import (
 
 	// Packages
 	nat "github.com/docker/go-connections/nat"
-	testcontainers "github.com/testcontainers/testcontainers-go"
-	wait "github.com/testcontainers/testcontainers-go/wait"
 	assert "github.com/stretchr/testify/assert"
 	require "github.com/stretchr/testify/require"
+	testcontainers "github.com/testcontainers/testcontainers-go"
+	wait "github.com/testcontainers/testcontainers-go/wait"
 )
 
 func Test_Opt_001(t *testing.T) {


### PR DESCRIPTION
This pull request enhances the container test utilities by adding several new option functions to simplify and extend the configuration of test containers. It also introduces comprehensive unit tests to ensure these options work as intended.

New container option functions:

* Added `OptEntrypoint` to set the container entrypoint, and `OptCommand` to set the command to run in the container.
* Introduced `OptFile` and `OptFiles` to allow copying single or multiple files into the container before startup.
* Added `OptPorts` to expose and wait for one or more container ports, and `OptEnv` to set environment variables. [[1]](diffhunk://#diff-f807c0d3623138548c578edbc2b8591598f2ad880896e9ec2a4c197a79c1e802R55) [[2]](diffhunk://#diff-f807c0d3623138548c578edbc2b8591598f2ad880896e9ec2a4c197a79c1e802R28-R44)
* Implemented `OptWait` and `OptWaitLog` to add custom or log-based wait strategies for container readiness.
* Improved `OptPostgres` to configure PostgreSQL containers and add SQL readiness checks.

Internal improvements:

* Added `appendWaitStrategy` as a helper to merge wait strategies into the container request.

Testing:

* Added `pkg/test/opt_test.go` with unit tests covering all new option functions, verifying correct configuration and behavior.