### PR TITLE
Fix OptPorts to wait for listening ports, not exposed port

### DIFF
--- a/pkg/test/opt.go
+++ b/pkg/test/opt.go
@@ -52,11 +52,13 @@ func OptEnv(name, value string) Opt {
 	}
 }
 
-// OptPorts exposes one or more container ports and waits for an exposed port.
+// OptPorts exposes one or more container ports and waits for each requested port.
 func OptPorts(ports ...string) Opt {
 	return func(o *opts) error {
 		o.req.ExposedPorts = ports
-		o.appendWaitStrategy(wait.ForExposedPort())
+		for _, port := range ports {
+			o.appendWaitStrategy(wait.ForListeningPort(nat.Port(port)))
+		}
 		return nil
 	}
 }

--- a/pkg/test/opt_test.go
+++ b/pkg/test/opt_test.go
@@ -41,9 +41,18 @@ func Test_Opt_001(t *testing.T) {
 	multi, ok := o.req.WaitingFor.(*wait.MultiStrategy)
 	require.True(ok)
 	assert.Len(multi.Strategies, 3)
-	assert.IsType(wait.ForListeningPort(nat.Port("3389/tcp")), multi.Strategies[0])
-	assert.IsType(wait.ForListeningPort(nat.Port("389/tcp")), multi.Strategies[1])
-	assert.IsType(wait.ForLog("server ready"), multi.Strategies[2])
+
+	strategy0, ok := multi.Strategies[0].(*wait.HostPortStrategy)
+	require.True(ok)
+	assert.Equal(nat.Port("3389/tcp"), strategy0.Port)
+
+	strategy1, ok := multi.Strategies[1].(*wait.HostPortStrategy)
+	require.True(ok)
+	assert.Equal(nat.Port("389/tcp"), strategy1.Port)
+
+	strategy2, ok := multi.Strategies[2].(*wait.LogStrategy)
+	require.True(ok)
+	assert.Equal("server ready", strategy2.Log)
 }
 
 func Test_Opt_002(t *testing.T) {

--- a/pkg/test/opt_test.go
+++ b/pkg/test/opt_test.go
@@ -21,19 +21,18 @@ func Test_Opt_001(t *testing.T) {
 	require.NoError(OptEntrypoint("/bin/sh", "-c")(&o))
 	require.NoError(OptCommand([]string{"echo", "hello"})(&o))
 	require.NoError(OptEnv("A", "1")(&o))
-	require.NoError(OptPorts("3389/tcp")(&o))
+	require.NoError(OptPorts("3389/tcp", "389/tcp")(&o))
 	require.NoError(OptFile(testcontainers.ContainerFile{
 		Reader:            strings.NewReader("echo bootstrap\n"),
 		ContainerFilePath: "/bootstrap.sh",
 		FileMode:          0o755,
 	})(&o))
-	require.NoError(OptWait(wait.ForListeningPort(nat.Port("3389/tcp")))(&o))
 	require.NoError(OptWaitLog("server ready")(&o))
 
 	assert.Equal([]string{"/bin/sh", "-c"}, o.req.Entrypoint)
 	assert.Equal([]string{"echo", "hello"}, o.req.Cmd)
 	assert.Equal("1", o.req.Env["A"])
-	assert.Equal([]string{"3389/tcp"}, o.req.ExposedPorts)
+	assert.Equal([]string{"3389/tcp", "389/tcp"}, o.req.ExposedPorts)
 	if assert.Len(o.req.Files, 1) {
 		assert.Equal("/bootstrap.sh", o.req.Files[0].ContainerFilePath)
 		assert.Equal(int64(0o755), o.req.Files[0].FileMode)
@@ -42,8 +41,8 @@ func Test_Opt_001(t *testing.T) {
 	multi, ok := o.req.WaitingFor.(*wait.MultiStrategy)
 	require.True(ok)
 	assert.Len(multi.Strategies, 3)
-	assert.IsType(wait.ForExposedPort(), multi.Strategies[0])
-	assert.IsType(wait.ForListeningPort(nat.Port("3389/tcp")), multi.Strategies[1])
+	assert.IsType(wait.ForListeningPort(nat.Port("3389/tcp")), multi.Strategies[0])
+	assert.IsType(wait.ForListeningPort(nat.Port("389/tcp")), multi.Strategies[1])
 	assert.IsType(wait.ForLog("server ready"), multi.Strategies[2])
 }
 


### PR DESCRIPTION
This pull request updates how container ports are exposed and waited for in tests. Instead of waiting for just one port, the system now waits for each requested port individually. The related test has been updated to check for multiple ports and their corresponding wait strategies.

**Port exposure and waiting improvements:**

* Modified `OptPorts` in `opt.go` to wait for each requested port individually by appending a `wait.ForListeningPort` strategy for every port, instead of a single generic wait.
* Updated the `Test_Opt_001` test in `opt_test.go` to use multiple ports (`"3389/tcp"`, `"389/tcp"`), verify that both are exposed, and check that a wait strategy is set up for each port. [[1]](diffhunk://#diff-f75addab49cf420c532d03ce8f12a9e0aad40c74defbb864563225a8b3d28818L24-R35) [[2]](diffhunk://#diff-f75addab49cf420c532d03ce8f12a9e0aad40c74defbb864563225a8b3d28818L45-R45)