### PR TITLE
Update pool binds to use copy on operation

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -55,6 +55,11 @@ func (bind *Bind) Copy(pairs ...any) *Bind {
 	if len(pairs)%2 != 0 {
 		return nil
 	}
+	if len(pairs) == 0 {
+		bind.RLock()
+		defer bind.RUnlock()
+		return &Bind{vars: maps.Clone(bind.vars), dblink: bind.dblink}
+	}
 
 	// Lock before copying
 	varsCopy := func() pgx.NamedArgs {

--- a/bind_benchmark_test.go
+++ b/bind_benchmark_test.go
@@ -1,0 +1,65 @@
+package pg
+
+import (
+	"maps"
+	"testing"
+
+	// Packages
+	pgx "github.com/jackc/pgx/v5"
+)
+
+func Benchmark_Bind_Copy_NoArgs(b *testing.B) {
+	bind := NewBind(
+		"a", "b",
+		"c", 123,
+		"d", true,
+		"e", []string{"x", "y", "z"},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = bind.Copy()
+	}
+}
+
+func Benchmark_Bind_Copy_NoArgs_PreviousStyle(b *testing.B) {
+	bind := NewBind(
+		"a", "b",
+		"c", 123,
+		"d", true,
+		"e", []string{"x", "y", "z"},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = previousStyleCopy(bind)
+	}
+}
+
+func Benchmark_Bind_Copy_WithPairs(b *testing.B) {
+	bind := NewBind(
+		"a", "b",
+		"c", 123,
+		"d", true,
+		"e", []string{"x", "y", "z"},
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = bind.Copy("f", "g", "h", 456)
+	}
+}
+
+func previousStyleCopy(bind *Bind) *Bind {
+	varsCopy := func() pgx.NamedArgs {
+		bind.RLock()
+		defer bind.RUnlock()
+		c := make(pgx.NamedArgs, len(bind.vars))
+		maps.Copy(c, bind.vars)
+		return c
+	}()
+	return &Bind{vars: varsCopy, dblink: bind.dblink}
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -99,3 +99,29 @@ func Test_Query_001(t *testing.T) {
 	sql := bind.Query("user.select")
 	assert.Equal("SELECT * FROM users WHERE id = @id", sql)
 }
+
+func Test_Bind_Copy_001(t *testing.T) {
+	assert := assert.New(t)
+
+	bind := pg.NewBind("a", "b")
+	copy := bind.Copy()
+	if assert.NotNil(copy) {
+		assert.Equal("b", copy.Get("a"))
+	}
+
+	copy.Set("a", "c")
+	assert.Equal("b", bind.Get("a"))
+	assert.Equal("c", copy.Get("a"))
+}
+
+func Test_Bind_Copy_002(t *testing.T) {
+	assert := assert.New(t)
+
+	bind := pg.NewBind("a", "b")
+	copy := bind.Copy("c", "d")
+	if assert.NotNil(copy) {
+		assert.Equal("b", copy.Get("a"))
+		assert.Equal("d", copy.Get("c"))
+	}
+	assert.False(bind.Has("c"))
+}

--- a/pool.go
+++ b/pool.go
@@ -145,12 +145,12 @@ func (p *poolconn) Remote(database string) Conn {
 
 // Perform a transaction, then commit or rollback
 func (p *poolconn) Tx(ctx context.Context, fn func(conn Conn) error) error {
-	return tx(ctx, p.conn, p.bind, fn)
+	return tx(ctx, p.conn, p.bind.Copy(), fn)
 }
 
 // Perform a bulk operation
 func (p *poolconn) Bulk(ctx context.Context, fn func(conn Conn) error) error {
-	return bulk(ctx, p.conn, p.bind, fn)
+	return bulk(ctx, p.conn, p.bind.Copy(), fn)
 }
 
 // Subscribe to a PostgreSQL notification channel using a dedicated connection.
@@ -162,32 +162,32 @@ func (p *poolconn) Subscribe(ctx context.Context, channel string) (<-chan Notifi
 
 // Execute a query
 func (p *poolconn) Exec(ctx context.Context, query string) error {
-	return p.bind.exec(ctx, p.conn, query)
+	return p.bind.Copy().exec(ctx, p.conn, query)
 }
 
 // Perform an insert
 func (p *poolconn) Insert(ctx context.Context, reader Reader, writer Writer) error {
-	return insert(ctx, p.conn, p.bind, reader, writer)
+	return insert(ctx, p.conn, p.bind.Copy(), reader, writer)
 }
 
 // Perform a update
 func (p *poolconn) Update(ctx context.Context, reader Reader, sel Selector, writer Writer) error {
-	return update(ctx, p.conn, p.bind, reader, sel, writer)
+	return update(ctx, p.conn, p.bind.Copy(), reader, sel, writer)
 }
 
 // Perform a delete
 func (p *poolconn) Delete(ctx context.Context, reader Reader, sel Selector) error {
-	return del(ctx, p.conn, p.bind, reader, sel)
+	return del(ctx, p.conn, p.bind.Copy(), reader, sel)
 }
 
 // Perform a get
 func (p *poolconn) Get(ctx context.Context, reader Reader, sel Selector) error {
-	return get(ctx, p.conn, p.bind, reader, sel)
+	return get(ctx, p.conn, p.bind.Copy(), reader, sel)
 }
 
 // Perform a list
 func (p *poolconn) List(ctx context.Context, reader Reader, sel Selector) error {
-	return list(ctx, p.conn, p.bind, reader, sel)
+	return list(ctx, p.conn, p.bind.Copy(), reader, sel)
 }
 
 func (p *pool) addSubscription(cancel context.CancelFunc) (*subscription, error) {


### PR DESCRIPTION
This pull request improves the safety and correctness of the `Bind.Copy` method and updates its usage throughout the codebase to prevent shared state issues. It also adds thorough testing and benchmarking for the new copy behavior.

**Improvements to `Bind.Copy` method:**

* Updated `Bind.Copy` to handle the case where no arguments are passed by returning a deep copy of the `vars` map, ensuring thread safety and preventing shared state between copies.

**Refactoring usage to ensure isolation:**

* Updated all usages of `Bind` in `poolconn` methods (such as `Tx`, `Bulk`, `Exec`, `Insert`, `Update`, `Delete`, `Get`, and `List`) to use a copy of the `Bind` instance, preventing unintended side effects from shared state. [[1]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L148-R153) [[2]](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L165-R190)

**Testing and benchmarking:**

* Added new unit tests in `bind_test.go` to verify that copies of `Bind` are independent and modifications to one do not affect the other.
* Introduced benchmarks in `bind_benchmark_test.go` to compare the performance of the new and previous copy implementations, including cases with and without additional key-value pairs.