### PR TITLE
Refactor tests for improved clarity and maintainability

### DIFF
--- a/pkg/broadcaster/broadcaster_test.go
+++ b/pkg/broadcaster/broadcaster_test.go
@@ -22,7 +22,10 @@ var conn test.Conn
 // TEST MAIN
 
 func TestMain(m *testing.M) {
-	test.Main(m, &conn, nil)
+	test.Main(m, func(pool pg.PoolConn) (func(), error) {
+		conn = test.Conn{PoolConn: pool}
+		return nil, nil
+	})
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/manager/database_test.go
+++ b/pkg/manager/database_test.go
@@ -17,7 +17,10 @@ var conn test.Conn
 
 // Start up a container and test the pool
 func TestMain(m *testing.M) {
-	test.Main(m, &conn, nil)
+	test.Main(m, func(pool pg.PoolConn) (func(), error) {
+		conn = test.Conn{PoolConn: pool}
+		return nil, nil
+	})
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -18,7 +18,10 @@ var conn test.Conn
 
 // Start up a container and test the pool
 func TestMain(m *testing.M) {
-	test.Main(m, &conn, nil)
+	test.Main(m, func(pool pg.PoolConn) (func(), error) {
+		conn = test.Conn{PoolConn: pool}
+		return nil, nil
+	})
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/test/README.md
+++ b/pkg/test/README.md
@@ -21,7 +21,10 @@ import (
 var conn pgtest.Conn
 
 func TestMain(m *testing.M) {
-  pgtest.Main(m, &conn, nil)
+  pgtest.Main(m, func(pool pg.PoolConn) (func(), error) {
+    conn = pgtest.Conn{PoolConn: pool}
+    return nil, nil
+  })
 }
 
 func TestSomething(t *testing.T) {

--- a/pkg/test/doc.go
+++ b/pkg/test/doc.go
@@ -7,21 +7,24 @@
 // For example, in order to test postgres integration tests, use the following
 // boilerplate for your tests:
 //
-//		// Global variable which will hold the connection
-//		var conn test.Conn
+//	// Global variable which will hold the connection
+//	var conn test.Conn
 //
-//	 // Start up a container and return the connection
-//		func TestMain(m *testing.M) {
-//						test.Main(m, &conn, nil)
-//					}
+//	// Start up a container and return the connection
+//	func TestMain(m *testing.M) {
+//				test.Main(m, func(pool pg.PoolConn) (func(), error) {
+//					conn = test.Conn{PoolConn: pool}
+//					return nil, nil
+//				})
+//			}
 //
-//			     // Run a test which pings the database
-//					func Test_Pool_001(t *testing.T) {
-//						assert := assert.New(t)
-//						conn := conn.Begin(t)
-//						defer conn.Close()
+//		     // Run a test which pings the database
+//				func Test_Pool_001(t *testing.T) {
+//					assert := assert.New(t)
+//					conn := conn.Begin(t)
+//					defer conn.Close()
 //
-//						// Ping the database
-//						assert.NoError(conn.Ping(context.Background()))
-//					}
+//					// Ping the database
+//					assert.NoError(conn.Ping(context.Background()))
+//				}
 package test

--- a/pkg/test/main.go
+++ b/pkg/test/main.go
@@ -12,6 +12,7 @@ import (
 	// Packages
 	pg "github.com/mutablelogic/go-pg"
 	manager "github.com/mutablelogic/go-pg/pkg/manager"
+	types "github.com/mutablelogic/go-server/pkg/types"
 )
 
 /////////////////////////////////////////////////////////////////////
@@ -37,11 +38,11 @@ const (
 // and runs the tests in the provided testing.M. The provided setup function can be used to perform any additional
 // setup before running the tests, such as initializing the database schema.
 // The returned cleanup function from setup will be called after the tests are complete to clean up any resources.
-func Main(m *testing.M, conn *Conn, setup func(*Conn) (func(), error)) {
-	os.Exit(main(m, conn, setup))
+func Main(m *testing.M, setup func(pg.PoolConn) (func(), error)) {
+	os.Exit(main(m, setup))
 }
 
-func main(m *testing.M, conn *Conn, setup func(*Conn) (func(), error)) int {
+func main(m *testing.M, setup func(pg.PoolConn) (func(), error)) int {
 	// Context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -72,13 +73,10 @@ func main(m *testing.M, conn *Conn, setup func(*Conn) (func(), error)) int {
 	defer pool.Close()
 	defer container.Close(ctx)
 
-	// Set the connection
-	*conn = Conn{pool, nil}
-
 	// Run setup if provided
 	cleanup := func() {}
 	if setup != nil {
-		cleanup_, err := setup(conn)
+		cleanup_, err := setup(types.Ptr(Conn{pool, nil}))
 		if err != nil {
 			panic(err)
 		} else if cleanup_ != nil {
@@ -92,7 +90,7 @@ func main(m *testing.M, conn *Conn, setup func(*Conn) (func(), error)) int {
 }
 
 // Begin a test
-func (c *Conn) Begin(t *testing.T) *Conn {
+func (c *Conn) Begin(t *testing.T) pg.PoolConn {
 	t.Log("Begin", t.Name())
 	return &Conn{c.PoolConn, t}
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -21,7 +21,10 @@ var conn test.Conn
 
 // Start up a container and test the pool
 func TestMain(m *testing.M) {
-	test.Main(m, &conn, nil)
+	test.Main(m, func(pool pg.PoolConn) (func(), error) {
+		conn = test.Conn{PoolConn: pool}
+		return nil, nil
+	})
 }
 
 func Test_Pool_001(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the test setup pattern across several packages to use a functional approach for initializing database connections in tests. The main change is replacing the previous pattern of passing a pointer to a connection struct into the test helper with a setup function that receives a `pg.PoolConn` and returns an optional cleanup function. This improves flexibility and consistency in test initialization.

**Test setup refactoring:**

* Updated the `test.Main` and `pgtest.Main` functions (and their usage in test files) to accept a setup function that receives a `pg.PoolConn` and returns a cleanup function, instead of passing a pointer to a connection struct and a setup function. This change affects `pkg/test/main.go`, `pkg/broadcaster/broadcaster_test.go`, `pkg/manager/database_test.go`, `pkg/queue/manager_test.go`, and `pool_test.go`. [[1]](diffhunk://#diff-03a673cca5d75a4880fd3720d790e238ce82aa3ac8ea273502d4fc9388d6ef3aL40-R45) [[2]](diffhunk://#diff-2b229ea59b04d61e66bc80a49d1da29b76e218cba8d3ca77c3c455e87bd04f4fL25-R28) [[3]](diffhunk://#diff-1925a7a72b2bfe6a1660a8e81ebf1569e09058666cce18b8784431d030ef25a7L20-R23) [[4]](diffhunk://#diff-3a463f6c4c15bd120b9754577f751fe46ff302306c9b8469ff4f41aa55dadcf9L21-R24) [[5]](diffhunk://#diff-080f4afaab90af50165762eb8438f21979a427a42f7cb821c0ccf192fd3afa98L24-R27) [[6]](diffhunk://#diff-81d2c6749a5cb2d9b8b675228caf23dd478c2659ace246ed4786263ae270f163L24-R27)

* Updated documentation and usage examples in `pkg/test/README.md` and `pkg/test/doc.go` to reflect the new setup pattern for test initialization. [[1]](diffhunk://#diff-81d2c6749a5cb2d9b8b675228caf23dd478c2659ace246ed4786263ae270f163L24-R27) [[2]](diffhunk://#diff-ed34744a9840c756ea7cd4ed62d0330ad990e37780a7a50680e09791096e4fbcL15-R18)

**Code improvements and minor changes:**

* Changed the `Begin` method on `Conn` to return a `pg.PoolConn` interface instead of a pointer to `Conn`, improving abstraction.

* Added a missing import for `types` in `pkg/test/main.go` to support the use of `types.Ptr`.

* Internally, the main test helper now constructs and passes the connection struct via the setup function, rather than setting it via pointer assignment.

These changes make the test setup more modular and easier to extend for future needs.