### PR TITLE
Fixed some logic around queue task pickup

### DIFF
--- a/pgqueue/manager/run.go
+++ b/pgqueue/manager/run.go
@@ -83,6 +83,7 @@ func (manager *Manager) Run(ctx context.Context, log *slog.Logger) error {
 
 		// Process as many tasks as we have capacity for, until there are
 		// no more tasks or an error occurs.
+		processed := false
 		for i := 0; i < runtime.GOMAXPROCS(0); i++ {
 			// Get next task for the queue
 			var task *schema.Task
@@ -94,13 +95,16 @@ func (manager *Manager) Run(ctx context.Context, log *slog.Logger) error {
 			if err != nil {
 				return false, err
 			} else if task == nil {
-				// No more tasks
-				return false, nil
+				// No more tasks can be retained right now. If we processed at
+				// least one task in this pass, ask the scheduler to check again
+				// soon to keep draining the queue.
+				return processed, nil
 			}
 
 			// Run the task callback - results are logged in the callback,
 			// so we don't need to do anything with them here.
 			manager.queues.RunQueueTask(child, task, results)
+			processed = true
 		}
 
 		// Return success


### PR DESCRIPTION
This pull request makes a small but important change to the task processing loop in `pgqueue/manager/run.go`. The update ensures that if at least one task was processed during a pass, the scheduler is prompted to check the queue again soon, helping to keep the queue draining efficiently.

Task processing logic improvement:

* Modified the loop in the `Manager.Run` method to track whether any tasks were processed in the current pass and return this information, allowing the scheduler to make better decisions about when to re-check the queue. [[1]](diffhunk://#diff-5c2ad0eb5fe99d7dc6b8ab295afcebb8e6b8c546cbcdc3dd3110ac54ec77ff30R86) [[2]](diffhunk://#diff-5c2ad0eb5fe99d7dc6b8ab295afcebb8e6b8c546cbcdc3dd3110ac54ec77ff30L97-R107)