### PR TITLE
Added permanent failure support

### DIFF
--- a/pgqueue/manager/exec.go
+++ b/pgqueue/manager/exec.go
@@ -189,6 +189,38 @@ func (exec *exec) RunQueueTask(ctx context.Context, task *schema.Task, result ch
 }
 
 func run(ctx context.Context, fn schema.TaskFunc, payload json.RawMessage) (resp *Result) {
+	return runWithGrace(ctx, fn, payload, time.Minute)
+}
+
+func runWithGrace(ctx context.Context, fn schema.TaskFunc, payload json.RawMessage, grace time.Duration) (resp *Result) {
+	result := make(chan *Result, 1)
+	go func() {
+		result <- runCallback(ctx, fn, payload)
+	}()
+
+	select {
+	case resp := <-result:
+		return resp
+	case <-ctx.Done():
+		// TTL is cooperative via context cancellation. Give callbacks an
+		// additional grace window to exit before force-failing the task.
+		if grace <= 0 {
+			return types.Ptr(Result{Error: context.DeadlineExceeded})
+		}
+
+		timer := time.NewTimer(grace)
+		defer timer.Stop()
+
+		select {
+		case resp := <-result:
+			return resp
+		case <-timer.C:
+			return types.Ptr(Result{Error: fmt.Errorf("task exceeded TTL and did not stop after %s grace period: %w", grace, context.DeadlineExceeded)})
+		}
+	}
+}
+
+func runCallback(ctx context.Context, fn schema.TaskFunc, payload json.RawMessage) (resp *Result) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			var err error

--- a/pgqueue/manager/exec.go
+++ b/pgqueue/manager/exec.go
@@ -202,10 +202,15 @@ func runWithGrace(ctx context.Context, fn schema.TaskFunc, payload json.RawMessa
 	case resp := <-result:
 		return resp
 	case <-ctx.Done():
+		cancelErr := ctx.Err()
+		if cancelErr == nil {
+			cancelErr = context.Canceled
+		}
+
 		// TTL is cooperative via context cancellation. Give callbacks an
 		// additional grace window to exit before force-failing the task.
 		if grace <= 0 {
-			return types.Ptr(Result{Error: context.DeadlineExceeded})
+			return types.Ptr(Result{Error: cancelErr})
 		}
 
 		timer := time.NewTimer(grace)
@@ -215,7 +220,7 @@ func runWithGrace(ctx context.Context, fn schema.TaskFunc, payload json.RawMessa
 		case resp := <-result:
 			return resp
 		case <-timer.C:
-			return types.Ptr(Result{Error: fmt.Errorf("task exceeded TTL and did not stop after %s grace period: %w", grace, context.DeadlineExceeded)})
+			return types.Ptr(Result{Error: fmt.Errorf("task did not stop after %s grace period following context cancellation: %w", grace, cancelErr)})
 		}
 	}
 }

--- a/pgqueue/manager/exec_test.go
+++ b/pgqueue/manager/exec_test.go
@@ -154,3 +154,39 @@ func TestRunQueueTaskRequiresTaskDeadline(t *testing.T) {
 
 	exec.Close()
 }
+
+func TestRunReturnsOnContextDeadlineWhenCallbackBlocks(t *testing.T) {
+	unblock := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	result := runWithGrace(ctx, func(context.Context, json.RawMessage) (any, error) {
+		<-unblock
+		return map[string]bool{"ok": true}, nil
+	}, nil, 20*time.Millisecond)
+	elapsed := time.Since(start)
+	close(unblock)
+
+	require.NotNil(t, result)
+	require.Error(t, result.Error)
+	assert.True(t, errors.Is(result.Error, context.DeadlineExceeded))
+	assert.Less(t, elapsed, 500*time.Millisecond)
+}
+
+func TestRunReturnsCallbackErrorIfItExitsDuringGrace(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	result := runWithGrace(ctx, func(ctx context.Context, _ json.RawMessage) (any, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}, nil, 100*time.Millisecond)
+	elapsed := time.Since(start)
+
+	require.NotNil(t, result)
+	require.Error(t, result.Error)
+	assert.True(t, errors.Is(result.Error, context.DeadlineExceeded))
+	assert.Less(t, elapsed, 500*time.Millisecond)
+}

--- a/pgqueue/manager/exec_test.go
+++ b/pgqueue/manager/exec_test.go
@@ -190,3 +190,26 @@ func TestRunReturnsCallbackErrorIfItExitsDuringGrace(t *testing.T) {
 	assert.True(t, errors.Is(result.Error, context.DeadlineExceeded))
 	assert.Less(t, elapsed, 500*time.Millisecond)
 }
+
+func TestRunWithGracePreservesCanceledCause(t *testing.T) {
+	unblock := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	start := time.Now()
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		cancel()
+	}()
+
+	result := runWithGrace(ctx, func(context.Context, json.RawMessage) (any, error) {
+		<-unblock
+		return map[string]bool{"ok": true}, nil
+	}, nil, 20*time.Millisecond)
+	elapsed := time.Since(start)
+	close(unblock)
+
+	require.NotNil(t, result)
+	require.Error(t, result.Error)
+	assert.True(t, errors.Is(result.Error, context.Canceled))
+	assert.Less(t, elapsed, 500*time.Millisecond)
+}

--- a/pgqueue/manager/manager.go
+++ b/pgqueue/manager/manager.go
@@ -71,6 +71,12 @@ func New(ctx context.Context, pool pg.PoolConn, opts ...Opt) (*Manager, error) {
 		self.PoolConn = pool
 	}
 
+	// Ensure at least one task partition exists before any task inserts happen.
+	if _, err := self.CreateNextPartition(bootstrapCtx); err != nil {
+		endBootstrapSpan(err)
+		return nil, err
+	}
+
 	// Register a maintenance ticker
 	if _, err := self.RegisterTicker(bootstrapCtx, schema.DefaultMaintenanceTickerName, schema.TickerMeta{
 		Interval: types.Ptr(schema.DefaultMaintenancePeriod),

--- a/pgqueue/manager/queue_test.go
+++ b/pgqueue/manager/queue_test.go
@@ -377,7 +377,7 @@ func TestNextTaskReclaimsExpiredRunningTask(t *testing.T) {
 		}
 	}()
 
-	_, err = mgr.CreateTask(ctx, queue.Queue, schema.TaskMeta{Payload: json.RawMessage(`{"task":1}`)})
+	firstTask, err := mgr.CreateTask(ctx, queue.Queue, schema.TaskMeta{Payload: json.RawMessage(`{"task":1}`)})
 	require.NoError(t, err)
 	_, err = mgr.CreateTask(ctx, queue.Queue, schema.TaskMeta{Payload: json.RawMessage(`{"task":2}`)})
 	require.NoError(t, err)
@@ -388,7 +388,19 @@ func TestNextTaskReclaimsExpiredRunningTask(t *testing.T) {
 		t.Fatal("timed out waiting for first queue task to start")
 	}
 
-	time.Sleep(ttl + 75*time.Millisecond)
+	require.Eventually(t, func() bool {
+		list, err := mgr.ListTasks(ctx, schema.TaskListRequest{Status: "expired"})
+		if err != nil {
+			return false
+		}
+		for _, item := range list.Body {
+			if item.Id == firstTask.Id {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 25*time.Millisecond, "timed out waiting for first task to expire")
+
 	_, err = mgr.CreateTask(ctx, queue.Queue, schema.TaskMeta{Payload: json.RawMessage(`{"task":3}`)})
 	require.NoError(t, err)
 

--- a/pgqueue/manager/queue_test.go
+++ b/pgqueue/manager/queue_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -322,6 +323,82 @@ func TestNextTaskWithZeroConcurrencyKeepsUnlimitedBehavior(t *testing.T) {
 	}
 
 	releaseOnce.Do(func() { close(release) })
+}
+
+func TestNextTaskReclaimsExpiredRunningTask(t *testing.T) {
+	mgr, ctx := test.Begin(t)
+	defer test.End(t)
+
+	beforeSeq, err := mgr.GetPartitionSeq(ctx)
+	require.NoError(t, err)
+
+	nextID := beforeSeq + 1
+	partitions, err := mgr.ListPartitions(ctx)
+	require.NoError(t, err)
+
+	createdPartition := ""
+	if !partitionContains(partitions, nextID) {
+		meta := schema.PartitionMeta{
+			Partition: "task_partition_queue_reclaim_expired",
+			Start:     1,
+			End:       1000000,
+		}
+		require.NoError(t, mgr.DeletePartition(ctx, meta.Partition))
+		require.NoError(t, mgr.CreatePartition(ctx, meta))
+		createdPartition = meta.Partition
+	}
+
+	ttl := 100 * time.Millisecond
+	concurrency := uint64(1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+	})
+	started := make(chan struct{}, 2)
+	var calls atomic.Uint32
+
+	queue, err := mgr.RegisterQueue(ctx, "queue_reclaim_expired", schema.QueueMeta{
+		TTL:         &ttl,
+		Concurrency: &concurrency,
+	}, func(context.Context, json.RawMessage) (any, error) {
+		started <- struct{}{}
+		if calls.Add(1) == 1 {
+			<-release
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+	defer func() {
+		releaseOnce.Do(func() { close(release) })
+		_, _ = mgr.DeleteQueue(ctx, queue.Queue)
+		if createdPartition != "" {
+			_ = mgr.DeletePartition(ctx, createdPartition)
+		}
+	}()
+
+	_, err = mgr.CreateTask(ctx, queue.Queue, schema.TaskMeta{Payload: json.RawMessage(`{"task":1}`)})
+	require.NoError(t, err)
+	_, err = mgr.CreateTask(ctx, queue.Queue, schema.TaskMeta{Payload: json.RawMessage(`{"task":2}`)})
+	require.NoError(t, err)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first queue task to start")
+	}
+
+	time.Sleep(ttl + 75*time.Millisecond)
+	_, err = mgr.CreateTask(ctx, queue.Queue, schema.TaskMeta{Payload: json.RawMessage(`{"task":3}`)})
+	require.NoError(t, err)
+
+	// With the fix, the expired running task no longer blocks queue progress,
+	// so another task attempt can start after TTL expiry.
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for queue progress after expired running task")
+	}
 }
 
 func TestRunQueueTaskResultIsReleasedDone(t *testing.T) {

--- a/pgqueue/manager/run.go
+++ b/pgqueue/manager/run.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"runtime"
 	"strings"
@@ -169,7 +170,12 @@ func (manager *Manager) Run(ctx context.Context, log *slog.Logger) error {
 				}
 				status := ""
 				if _, err := manager.ReleaseTask(resultCtx, result.Task.Id, success, releaseResult, &status); err != nil {
-					log.ErrorContext(resultCtx, "ReleaseTask failed", "queue", result.Queue, "task", result.Task.Id, "error", err.Error())
+					if errors.Is(err, pg.ErrNotFound) {
+						log.WarnContext(resultCtx, "Late queue task result ignored", "queue", result.Queue, "task", result.Task.Id)
+						queueTimer.Reset(0)
+					} else {
+						log.ErrorContext(resultCtx, "ReleaseTask failed", "queue", result.Queue, "task", result.Task.Id, "error", err.Error())
+					}
 					continue
 				}
 				if result.Error != nil {

--- a/pgqueue/manager/run.go
+++ b/pgqueue/manager/run.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -194,7 +195,7 @@ func (manager *Manager) Run(ctx context.Context, log *slog.Logger) error {
 				// Completed ticker task
 				if result.Error != nil {
 					log.ErrorContext(resultCtx, "RunTickerTask result failed", "ticker", result.Ticker, "error", result.Error.Error())
-				} else {
+				} else if len(result.Result) > 0 && !bytes.Equal(result.Result, []byte("null")) {
 					log.InfoContext(resultCtx, "RunTickerTask result", "ticker", result.Ticker, "result", result)
 				}
 			}

--- a/pgqueue/schema/objects.sql
+++ b/pgqueue/schema/objects.sql
@@ -170,6 +170,8 @@ WITH selected AS (
             "started_at" IS NOT NULL
         AND
             "finished_at" IS NULL
+        AND
+            ("dies_at" IS NULL OR "dies_at" >= NOW())
         GROUP BY
             "queue"
     ) retained
@@ -178,7 +180,11 @@ WITH selected AS (
     WHERE
         (CARDINALITY(q) = 0 OR t."queue" = ANY(q))
     AND
-        (t."started_at" IS NULL AND t."finished_at" IS NULL)
+        (
+            (t."started_at" IS NULL AND t."finished_at" IS NULL)
+            OR
+            (t."started_at" IS NOT NULL AND t."finished_at" IS NULL AND t."dies_at" IS NOT NULL AND t."dies_at" < NOW())
+        )
     AND
         (t."delayed_at" IS NULL OR t."delayed_at" <= NOW())
     AND


### PR DESCRIPTION
This pull request introduces improvements to task queue management in the `pgqueue` package, focusing on more robust handling of expired running tasks and ensuring partitions are available before task insertion. It also adds new tests to verify correct behavior when tasks exceed their TTL and when expired tasks are reclaimed, and updates the SQL schema to support these changes.

**Task execution and timeout handling:**

* Added `runWithGrace` and `runCallback` functions to allow task callbacks a configurable grace period to exit after context deadline, improving reliability when handling long-running or blocking tasks.
* Added tests to verify that tasks return errors if they exceed their TTL and that callback errors are handled correctly during the grace period.

**Partition and queue management:**

* Ensured at least one task partition exists before any task inserts, preventing failures during queue initialization.
* Added a test to verify that expired running tasks are reclaimed and do not block queue progress, using atomic counters and explicit partition management. [[1]](diffhunk://#diff-d7f4c242c29b97b4dabe4d679efe748c29e3394310be94d24255ebfb3e05b2bbR328-R403) [[2]](diffhunk://#diff-d7f4c242c29b97b4dabe4d679efe748c29e3394310be94d24255ebfb3e05b2bbR8)

**SQL schema updates:**

* Updated the SQL logic in `objects.sql` to exclude expired running tasks from the retained set and to allow selection of new tasks when previous running tasks have expired, enabling proper task reclamation. [[1]](diffhunk://#diff-f910b0bec38a63229cd843893de1f89cf7ddf8595a0f1afd54cd2b9d77fde9b9R173-R174) [[2]](diffhunk://#diff-f910b0bec38a63229cd843893de1f89cf7ddf8595a0f1afd54cd2b9d77fde9b9R183-R187)